### PR TITLE
Rework the release process

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -30,62 +30,40 @@ end
 
 task :default => [<% if File.exist?(File.join(@metadata[:workdir], ".rubocop.yml")) %>:rubocop, <% end %>:test]
 
-desc "Expands the action details section in a README.md file"
-task :readme_expand do
-  ddl_file = Dir.glob("agent/*.ddl").first
-
-  return unless ddl_file
-
-  ddl = MCollective::DDL.new("package", :agent, false)
-  ddl.instance_eval(File.read(ddl_file))
-
-  lines = File.readlines("puppet/README.md").map do |line|
-    if line.match?(/^<!--- actions -->/)
-      [
-        "## Actions\n\n",
-        "This agent provides the following actions, for details about each please run `mco plugin doc agent/%s`\n\n" % ddl.meta[:name]
-      ] + ddl.entities.keys.sort.map do |action|
-        " * **%s** - %s\n" % [action, ddl.entities[action][:description]]
-      end
-    else
-      line
-    end
-  end.flatten
-
-  File.open("puppet/README.md", "w") do |f|
-    f.print lines.join
-  end
-end
-
 desc "Set versions for a release"
 task :prep_version do
   abort("Please specify VERSION") unless ENV["VERSION"]
 
   Rake::FileList["**/*.ddl"].each do |file|
-    sh 'sed -i"" -re \'s/(\s+:version\s+=>\s+").+/\1%s",/\' %s' % [ENV["VERSION"], file]
-  end
-end
-
-desc "Prepares for a release"
-task :build_prep do
-  if ENV["VERSION"]
-    Rake::Task[:test].execute
-    Rake::Task[:prep_version].execute
+    sh 'sed -i "" -re \'s/([\t ]+:version[\t ]+=>[\t ]+").+/\\1%s",/\' %s' % [ENV["VERSION"], file]
   end
 
-  mkdir_p "puppet"
+  Rake::FileList["**/*.json"].each do |file|
+    sh 'sed -i "" -re \'s/("version": ").+/\\1%s",/\' %s' % [ENV["VERSION"], file]
+  end
 
-  cp "README.md", "puppet"
-  cp "CHANGELOG.md", "puppet"
-  cp "LICENSE", "puppet"
-  cp "NOTICE", "puppet"
+  changelog = File.read("CHANGELOG.md")
+  File.open("CHANGELOG.md", "w") do |f|
+    done = false
+    changelog.lines.each do |line|
+      if line =~ /^## / && !done
+        done = true
+        puts "Adding a new entry to CHANGELOG.md:"
+        puts "-------------------- 8< --------------------"
+        new_entry = <<~EOT
+          ## #{ENV["VERSION"]}
 
-  Rake::Task[:readme_expand].execute
-end
+          Released #{Time.now.strftime("%Y-%m-%d")}
 
-desc "Builds the module found in the current directory, run build_prep first"
-task :build do
-  sh "/opt/puppetlabs/puppet/bin/mco plugin package --format aiomodulepackage --vendor choria"
+          #{`git log --oneline $(git tag | tail -n 1)..HEAD`.lines.map { |l| l.sub(/^/, " * ")}.join }
+        EOT
+        puts new_entry
+        puts "-------------------- 8< --------------------"
+        f.puts new_entry
+      end
+      f.puts line
+    end
+  end
 end
 
 # load optional tasks for releases


### PR DESCRIPTION
Now that we use some of the Vox Pupuli tooling, we want to update the way
we prepare a release: the `release:prepare` rake tasks from Vox Pupuli
is not unsable with our current setup, so update he `prep_version` rake
tasks to update the version in both the .ddl and the .json files, and
also write some boilerplate in the `CHANGELOG.md` file.  The call
sequence is the same as used before to release a module:

```sh-session
$ bundle exec rake prep_version VERSION=5.5.0
```

When the changes are ready, a release is done from the `main` branch of
the repository by tagging the code and pushing the tag to GitHub where a
GitHub action will do the actual release:

```sh-session
$ git tag 5.5.0
$ git push --tags
```
