### PR TITLE
Manage modules manifests using ModuleSync

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,0 +1,14 @@
+def choria_module_name
+  case @metadata[:module_name]
+  when "action-policy"
+    "mcollective_util_actionpolicy"
+  when "mcollective_choria"
+    "mcollective_choria"
+  when "tasks-agent"
+    "mcollective_agent_bolt_tasks"
+  when /-agent$/
+    "mcollective_agent_#{@metadata[:module_name].sub(/-agent$/, '')}"
+  else
+    raise "Don't know how to construct module name"
+  end
+end

--- a/moduleroot/data/defaults.yaml.erb
+++ b/moduleroot/data/defaults.yaml.erb
@@ -1,30 +1,17 @@
-<%
-    module_name = case @metadata[:module_name]
-                  when "action-policy"
-                    "mcollective_util_actionpolicy"
-                  when "mcollective_choria"
-                    "mcollective_choria"
-                  when "tasks-agent"
-                    "mcollective_agent_bolt_tasks"
-                  when /-agent$/
-                    "mcollective_agent_#{@metadata[:module_name].sub(/-agent$/, '')}"
-                  else
-                    raise "Don't know how to construct module name"
-                  end
--%>
+<% require_relative '../../lib/util.rb' -%>
 lookup_options:
-  <%= module_name %>::gem_dependencies:
+  <%= choria_module_name %>::gem_dependencies:
     merge:
       strategy: deep
-  <%= module_name %>::package_dependencies:
+  <%= choria_module_name %>::package_dependencies:
     merge:
       strategy: deep
-  <%= module_name %>::config:
+  <%= choria_module_name %>::config:
     merge:
       strategy: deep
-  <%= module_name %>::client_config:
+  <%= choria_module_name %>::client_config:
     merge:
       strategy: deep
-  <%= module_name %>::server_config:
+  <%= choria_module_name %>::server_config:
     merge:
       strategy: deep

--- a/moduleroot/manifests/init.pp.erb
+++ b/moduleroot/manifests/init.pp.erb
@@ -1,0 +1,53 @@
+<% require_relative '../../lib/util.rb' -%>
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+class <%= choria_module_name %> (
+  String $config_name,
+  Array[String] $client_files = [],
+  Array[String] $client_directories = [],
+  Array[String] $server_files = [],
+  Array[String] $server_directories = [],
+  Array[String] $common_files = [],
+  Array[String] $common_directories = [],
+  Array[String] $executable_files = [],
+  Boolean $manage_gem_dependencies = true,
+  Hash $gem_dependencies = {},
+  Boolean $manage_package_dependencies = true,
+  Hash $package_dependencies = {},
+  Boolean $manage_class_dependencies = true,
+  Array[String] $class_dependencies = [],
+  Mcollective::Policy_action $policy_default = $mcollective::policy_default,
+  Array[Mcollective::Policy] $policies = [],
+  Array[Mcollective::Policy] $site_policies = $mcollective::site_policies,
+  Hash $config = {},
+  Hash $client_config = {},
+  Hash $server_config = {},
+  Boolean $client = $mcollective::client,
+  Boolean $server = $mcollective::server,
+  Enum["present", "absent"] $ensure = "present"
+) {
+  mcollective::module_plugin{$name:
+    config_name                 => $config_name,
+    client_files                => $client_files,
+    server_files                => $server_files,
+    common_files                => $common_files,
+    executable_files            => $executable_files,
+    client_directories          => $client_directories,
+    server_directories          => $server_directories,
+    common_directories          => $common_directories,
+    gem_dependencies            => $gem_dependencies,
+    manage_gem_dependencies     => $manage_gem_dependencies,
+    package_dependencies        => $package_dependencies,
+    manage_package_dependencies => $manage_package_dependencies,
+    class_dependencies          => $class_dependencies,
+    policy_default              => $policy_default,
+    policies                    => $policies,
+    site_policies               => $site_policies,
+    config                      => $config,
+    client_config               => $client_config,
+    server_config               => $server_config,
+    client                      => $client,
+    server                      => $server,
+    ensure                      => $ensure
+  }
+}

--- a/moduleroot/manifests/init.pp.erb
+++ b/moduleroot/manifests/init.pp.erb
@@ -24,9 +24,10 @@ class <%= choria_module_name %> (
   Hash $server_config = {},
   Boolean $client = $mcollective::client,
   Boolean $server = $mcollective::server,
-  Enum["present", "absent"] $ensure = "present"
+  Enum['present', 'absent'] $ensure = 'present'
 ) {
   mcollective::module_plugin{$name:
+    ensure                      => $ensure,
     config_name                 => $config_name,
     client_files                => $client_files,
     server_files                => $server_files,
@@ -48,6 +49,5 @@ class <%= choria_module_name %> (
     server_config               => $server_config,
     client                      => $client,
     server                      => $server,
-    ensure                      => $ensure
   }
 }


### PR DESCRIPTION
All puppet modules managed with this repo are supposed to share a similar `manifests/init.pp` file, but in reality these files have slight differences that ModuleSync allows to avoid.

Also, the modules on the Puppet forge have quite a bad quality score partly due to some style issues ([example](https://forgeapi.puppetlabs.com/private/validations/choria-mcollective_agent_filemgr)), so this PR also improve this.